### PR TITLE
Feature Golf - Added swap functionality and fixed delay.

### DIFF
--- a/FontysSports/Assets/Prefab/Golf/GolfClub.prefab
+++ b/FontysSports/Assets/Prefab/Golf/GolfClub.prefab
@@ -215,6 +215,7 @@ GameObject:
   m_Component:
   - component: {fileID: 494430774154785904}
   - component: {fileID: 1160179721043306795}
+  - component: {fileID: 5272526694656982268}
   m_Layer: 0
   m_Name: GolfClub
   m_TagString: Untagged
@@ -265,6 +266,21 @@ Rigidbody:
   m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 1
+--- !u!114 &5272526694656982268
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3022474476115163117}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0d40750ac82f1d4489400849d3138abb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  colliders:
+  - {fileID: 8804410172647766083}
+  - {fileID: 1320377027560078709}
 --- !u!1 &3529661920208367431
 GameObject:
   m_ObjectHideFlags: 0

--- a/FontysSports/Assets/Prefab/Golf/GolfClub.prefab
+++ b/FontysSports/Assets/Prefab/Golf/GolfClub.prefab
@@ -264,7 +264,7 @@ Rigidbody:
   m_IsKinematic: 1
   m_Interpolate: 1
   m_Constraints: 0
-  m_CollisionDetection: 2
+  m_CollisionDetection: 1
 --- !u!1 &3529661920208367431
 GameObject:
   m_ObjectHideFlags: 0
@@ -601,7 +601,7 @@ Transform:
   m_GameObject: {fileID: 6818701253022897547}
   serializedVersion: 2
   m_LocalRotation: {x: 0.5, y: 0, z: 0, w: 0.8660254}
-  m_LocalPosition: {x: 0, y: -0.06, z: -0.104}
+  m_LocalPosition: {x: 0, y: -0.09, z: -0.179}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:

--- a/FontysSports/Assets/Prefab/Golf/GolfClub.prefab
+++ b/FontysSports/Assets/Prefab/Golf/GolfClub.prefab
@@ -120,6 +120,59 @@ Transform:
   - {fileID: 6346786317375910295}
   m_Father: {fileID: 3246605013919947533}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2258809982741470561
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1240956170613652715}
+  - component: {fileID: 3133467826029367865}
+  m_Layer: 11
+  m_Name: ClubHeadCollider_Bigly
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1240956170613652715
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2258809982741470561}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: -0.043619405, w: 0.9990483}
+  m_LocalPosition: {x: -0.0199, y: 0.0362, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3361901020058217667}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: -5}
+--- !u!65 &3133467826029367865
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2258809982741470561}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 0
+  serializedVersion: 3
+  m_Size: {x: 0.2, y: 0.15, z: 0.025}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &2266253259498094296
 GameObject:
   m_ObjectHideFlags: 0
@@ -216,6 +269,7 @@ GameObject:
   - component: {fileID: 494430774154785904}
   - component: {fileID: 1160179721043306795}
   - component: {fileID: 5272526694656982268}
+  - component: {fileID: 7490445262917527977}
   m_Layer: 0
   m_Name: GolfClub
   m_TagString: Untagged
@@ -281,6 +335,21 @@ MonoBehaviour:
   colliders:
   - {fileID: 8804410172647766083}
   - {fileID: 1320377027560078709}
+--- !u!114 &7490445262917527977
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3022474476115163117}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1f9457f6b9c70354497728787b2a0c2a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  speedThreshold: 0.01
+  clubHead: {fileID: 3361901020058217667}
+  bigCollider: {fileID: 3133467826029367865}
 --- !u!1 &3529661920208367431
 GameObject:
   m_ObjectHideFlags: 0
@@ -746,6 +815,7 @@ Transform:
   - {fileID: 1256870360598237993}
   - {fileID: 3251466499789644539}
   - {fileID: 4997368762830101484}
+  - {fileID: 1240956170613652715}
   m_Father: {fileID: 3246605013919947533}
   m_LocalEulerAnglesHint: {x: 0, y: -90, z: 0}
 --- !u!1 &7942981582175359424

--- a/FontysSports/Assets/Prefab/SportEquipmentFollowHandler.prefab
+++ b/FontysSports/Assets/Prefab/SportEquipmentFollowHandler.prefab
@@ -245,7 +245,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 7985017190999010518}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f655b55a0b51463459cda810de4487d6, type: 3}
+  m_Script: {fileID: 11500000, guid: 090c8154974c6154ab52eb2864eeb8da, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   rightControllerActive: 1

--- a/FontysSports/Assets/Prefab/SportEquipmentFollowHandler.prefab
+++ b/FontysSports/Assets/Prefab/SportEquipmentFollowHandler.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 3321867109164222534}
   - component: {fileID: 5214408427027502384}
   m_Layer: 0
-  m_Name: RightController
+  m_Name: RightControllerFollower
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -112,7 +112,7 @@ GameObject:
   - component: {fileID: 1990686428417568906}
   - component: {fileID: 4040534196452741201}
   m_Layer: 0
-  m_Name: LeftController
+  m_Name: LeftControllerFollower
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -249,6 +249,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rightControllerActive: 1
-  leftController: {fileID: 1990686428417568906}
-  rightController: {fileID: 3321867109164222534}
   sportEquipment: {fileID: 0}
+  leftIAR: {fileID: -4758839538258060184, guid: c348712bda248c246b8c49b3db54643f, type: 3}
+  leftControllerFollower: {fileID: 1990686428417568906}
+  rightIAR: {fileID: 1670121928723001259, guid: c348712bda248c246b8c49b3db54643f, type: 3}
+  rightControllerFollower: {fileID: 3321867109164222534}

--- a/FontysSports/Assets/Samples/XR Interaction Toolkit/3.0.7/Starter Assets/XRI Default Input Actions.inputactions
+++ b/FontysSports/Assets/Samples/XR Interaction Toolkit/3.0.7/Starter Assets/XRI Default Input Actions.inputactions
@@ -452,6 +452,15 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": true
+                },
+                {
+                    "name": "SwitchSportEquipment",
+                    "type": "Button",
+                    "id": "9c73d197-da9d-4169-b696-c96c3f5982ba",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -859,6 +868,17 @@
                     "processors": "",
                     "groups": "",
                     "action": "Thumbstick",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "e45b9355-8fb4-41b7-b3c1-b06ef0069742",
+                    "path": "<XRController>{LeftHand}/primaryButton",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "SwitchSportEquipment",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }
@@ -1523,6 +1543,15 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": true
+                },
+                {
+                    "name": "SwitchSportEquipment",
+                    "type": "Button",
+                    "id": "09ea8036-5c36-40a3-bc99-a7faac5e6974",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -1930,6 +1959,17 @@
                     "processors": "",
                     "groups": "",
                     "action": "Thumbstick",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "40815fa5-e5d1-42a3-86bb-e9b86d260e04",
+                    "path": "<XRController>{RightHand}/primaryButton",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "SwitchSportEquipment",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/FontysSports/Assets/Scripts/DisableColliders.cs
+++ b/FontysSports/Assets/Scripts/DisableColliders.cs
@@ -1,0 +1,18 @@
+using System.Collections;
+using UnityEngine;
+
+public class DisableColliders : MonoBehaviour
+{
+    [SerializeField] private Collider[] colliders;
+
+    public void Disable()
+    {
+        foreach (Collider col in colliders) col.enabled = false;
+    }
+
+    public IEnumerator Enable()
+    {
+        yield return new WaitForSeconds(0.1f);
+        foreach (Collider col in colliders) col.enabled = true;
+    }
+}

--- a/FontysSports/Assets/Scripts/DisableColliders.cs.meta
+++ b/FontysSports/Assets/Scripts/DisableColliders.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0d40750ac82f1d4489400849d3138abb

--- a/FontysSports/Assets/Scripts/Golf/GolfClubColliderSwitch.cs
+++ b/FontysSports/Assets/Scripts/Golf/GolfClubColliderSwitch.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+
+public class GolfClubColliderSwitch : MonoBehaviour
+{
+    [SerializeField] private float speedThreshold = 3;
+    [SerializeField] private Transform clubHead;
+    [SerializeField] private Collider bigCollider;
+
+    private Vector3 clubHeadPreviousPos = Vector3.zero;
+    private bool swapping = false;
+    private bool overSpeedThreshold = false;
+
+    private void FixedUpdate()
+    {
+        Vector3 clubHeadPos = clubHead.position;
+        float distance = Vector3.Distance(clubHeadPreviousPos, clubHeadPos);
+        if (overSpeedThreshold != distance >= speedThreshold) swapping = true;
+        overSpeedThreshold = distance >= speedThreshold;
+        clubHeadPreviousPos = clubHeadPos;
+
+        if (swapping)
+        {
+            bigCollider.enabled = overSpeedThreshold;
+            swapping = false;
+        }
+    }
+}

--- a/FontysSports/Assets/Scripts/Golf/GolfClubColliderSwitch.cs.meta
+++ b/FontysSports/Assets/Scripts/Golf/GolfClubColliderSwitch.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1f9457f6b9c70354497728787b2a0c2a

--- a/FontysSports/Assets/Scripts/SportEquipmentFollowHandler.cs
+++ b/FontysSports/Assets/Scripts/SportEquipmentFollowHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.XR.Interaction.Toolkit.Inputs;
@@ -5,28 +6,37 @@ using UnityEngine.XR.Interaction.Toolkit.Inputs;
 public class SportEquipmentFollowHandler : MonoBehaviour
 {
     [SerializeField] private bool rightControllerActive = true;
-    [SerializeField] private Transform leftController;
-    [SerializeField] private Transform rightController;
     [SerializeField] private GameObject sportEquipment;
+    [Space(10)]
+    [SerializeField] private InputActionReference leftIAR;
+    [SerializeField] private Transform leftControllerFollower;
+    [Space(10)]
+    [SerializeField] private InputActionReference rightIAR;
+    [SerializeField] private Transform rightControllerFollower;
 
     private Rigidbody sportEquipmentRigid;
 
-    private void Start()
+    private void OnEnable()
     {
-        sportEquipmentRigid = sportEquipment.GetComponent<Rigidbody>();
+        leftIAR.action.performed += SwitchController;
+        rightIAR.action.performed += SwitchController;
     }
+
+    private void SwitchController(InputAction.CallbackContext context) => rightControllerActive = !rightControllerActive;
+
+    private void Start() => sportEquipmentRigid = sportEquipment.GetComponent<Rigidbody>();
 
     private void FixedUpdate()
     {
         if (!rightControllerActive)
         {
-            sportEquipmentRigid.MovePosition(leftController.position);
-            sportEquipmentRigid.MoveRotation(leftController.rotation);
+            sportEquipmentRigid.MovePosition(leftControllerFollower.position);
+            sportEquipmentRigid.MoveRotation(leftControllerFollower.rotation);
         }
         else
         {
-            sportEquipmentRigid.MovePosition(rightController.position);
-            sportEquipmentRigid.MoveRotation(rightController.rotation);
+            sportEquipmentRigid.MovePosition(rightControllerFollower.position);
+            sportEquipmentRigid.MoveRotation(rightControllerFollower.rotation);
         }
     }
 }

--- a/FontysSports/Assets/Scripts/SportEquipmentFollowHandler.cs
+++ b/FontysSports/Assets/Scripts/SportEquipmentFollowHandler.cs
@@ -13,6 +13,8 @@ public class SportEquipmentFollowHandler : MonoBehaviour
     [SerializeField] private Transform rightControllerFollower;
 
     private Rigidbody sportEquipmentRigid;
+    private DisableColliders disableColliders;
+    private bool swapping = false;
 
     private void OnEnable()
     {
@@ -22,21 +24,32 @@ public class SportEquipmentFollowHandler : MonoBehaviour
 
     private void SwitchController(InputAction.CallbackContext context) => rightControllerActive = !rightControllerActive;
 
-    private void Start() => sportEquipmentRigid = sportEquipment.GetComponent<Rigidbody>();
+    private void Start()
+    {
+        sportEquipmentRigid = sportEquipment.GetComponent<Rigidbody>();
+        disableColliders = sportEquipment.GetComponent<DisableColliders>();
+    }
 
     private void FixedUpdate()
     {
-        if (!rightControllerActive)
+        if (!rightControllerActive) MoveSportEquipment(leftControllerFollower);
+        else MoveSportEquipment(rightControllerFollower);
+    }
+
+    private void MoveSportEquipment(Transform follower)
+    {
+        if (sportEquipment.transform.parent != follower)
         {
-            if (sportEquipment.transform.parent != leftControllerFollower) sportEquipment.transform.parent = leftControllerFollower;
-            sportEquipmentRigid.MovePosition(leftControllerFollower.position);
-            sportEquipmentRigid.MoveRotation(leftControllerFollower.rotation);
+            swapping = true;
+            disableColliders.Disable();
+            sportEquipment.transform.parent = follower;
         }
-        else
+        sportEquipmentRigid.MovePosition(follower.position);
+        sportEquipmentRigid.MoveRotation(follower.rotation);
+        if (swapping)
         {
-            if (sportEquipment.transform.parent != rightControllerFollower) sportEquipment.transform.parent = rightControllerFollower;
-            sportEquipmentRigid.MovePosition(rightControllerFollower.position);
-            sportEquipmentRigid.MoveRotation(rightControllerFollower.rotation);
+            StartCoroutine(disableColliders.Enable());
+            swapping = false;
         }
     }
 }

--- a/FontysSports/Assets/Scripts/SportEquipmentFollowHandler.cs
+++ b/FontysSports/Assets/Scripts/SportEquipmentFollowHandler.cs
@@ -1,7 +1,5 @@
-using System;
 using UnityEngine;
 using UnityEngine.InputSystem;
-using UnityEngine.XR.Interaction.Toolkit.Inputs;
 
 public class SportEquipmentFollowHandler : MonoBehaviour
 {
@@ -30,11 +28,13 @@ public class SportEquipmentFollowHandler : MonoBehaviour
     {
         if (!rightControllerActive)
         {
+            if (sportEquipment.transform.parent != leftControllerFollower) sportEquipment.transform.parent = leftControllerFollower;
             sportEquipmentRigid.MovePosition(leftControllerFollower.position);
             sportEquipmentRigid.MoveRotation(leftControllerFollower.rotation);
         }
         else
         {
+            if (sportEquipment.transform.parent != rightControllerFollower) sportEquipment.transform.parent = rightControllerFollower;
             sportEquipmentRigid.MovePosition(rightControllerFollower.position);
             sportEquipmentRigid.MoveRotation(rightControllerFollower.rotation);
         }

--- a/FontysSports/Assets/Scripts/SportEquipmentFollowHandler.cs.meta
+++ b/FontysSports/Assets/Scripts/SportEquipmentFollowHandler.cs.meta
@@ -1,2 +1,2 @@
 fileFormatVersion: 2
-guid: f655b55a0b51463459cda810de4487d6
+guid: 090c8154974c6154ab52eb2864eeb8da


### PR DESCRIPTION
# Context
The swap functionality is being triggered by pressing either primary buttons (Left = X, right = A). Delay issue is fixed by parenting the sport equipment to the corresponding controller follower.

## Files Changed
- GolfClub.prefab - Added DisableColliders.cs to the prefab which will be called in SportEquipmentFollowerHandler.cs when the controller follower is swapped.
- SportEquipmentFollowHandler.prefab - Added 'Follower' to the name of both children and linked the Input Action Reference(s).
- XRI Default Input Actions.inputactions - Added SwitchSportEquipment which is linked to the primary buttons of both controllers.
- SportEquipmentFollowHandler.cs - Added Input Action Reference(s) for both controllers' primary buttons. When either primary button is pressed the parent of sport equipment will be swapped. And the DisableColliders.cs will be used to prevent any unwanted collisions during the swap.

## Files Added
- DisableColliders.cs - The list of colliders of the sport equipment will be either disabled with Disable or enabled with Enable which has a small delay of 0.1f seconds.